### PR TITLE
Rename node id request header

### DIFF
--- a/hpn-provider/hpn-provider/src/util.rs
+++ b/hpn-provider/hpn-provider/src/util.rs
@@ -154,10 +154,8 @@ pub async fn call_provider(
             }
         }
     }
-    if !http_headers.contains_key("User-Agent") {
-        http_headers.insert("User-Agent".to_string(), source);
-    }
 
+    http_headers.insert("X-Insecure-HPN-Client-Node-Id".to_string(), source);
 
 
     kiprintln!(


### PR DESCRIPTION
In an earlier discussion it was agreed that this header would be better off with a custom name, since some APIs may expect other values for `UserAgent`.

My suggestion is `X-Insecure-HPN-Client-Node-Id`.

If Alice runs an HTTP weather API, and Bob sets up an HPN integration for it, Bob's `hpn-provider` process could send fake values of this header to Alice. If Alice doesn't know much about hyperware, she might assume the header is trustworthy somehow. The `Insecure` in the name should prevent that.