### PR TITLE
Provider refactor — curl-based configuration workflow

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
     "properties": {
         "package_name": "hypergrid",
         "current_version": "1.0.0",
-        "publisher": "ware.hypr",
+        "publisher": "test.hypr",
         "mirrors": ["sam.hypr", "backup-distro-node.os"],
         "code_hashes": {
             "1.0.0": "001a49117374abc3bdb38179d8ce05d76205b008bb55683e116be36f3e1635ce"

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
     "properties": {
         "package_name": "hypergrid",
         "current_version": "1.0.0",
-        "publisher": "test.hypr",
+        "publisher": "ware.hypr",
         "mirrors": ["sam.hypr", "backup-distro-node.os"],
         "code_hashes": {
             "1.0.0": "001a49117374abc3bdb38179d8ce05d76205b008bb55683e116be36f3e1635ce"

--- a/operator/metadata.json
+++ b/operator/metadata.json
@@ -5,7 +5,7 @@
     "properties": {
         "package_name": "hypergrid",
         "current_version": "0.1.2",
-        "publisher": "ware.hypr",
+        "publisher": "test.hypr",
         "mirrors": [],
         "code_hashes": {
             "0.1.0": "5ee79597d09c2ca644e41059489f1ed99eb8c5919b2830f9e3e4a1863cb0da88",

--- a/pkg/api/operator:sortugdev.os-v0.wit
+++ b/pkg/api/operator:sortugdev.os-v0.wit
@@ -1,4 +1,0 @@
-world operator-sortugdev-dot-os-v0 {
-    import operator;
-    include process-v1;
-}

--- a/pkg/manifest.json
+++ b/pkg/manifest.json
@@ -29,7 +29,8 @@
       "http-server:distro:sys",
       "vfs:distro:sys",
       "eth:distro:sys",
-      "sqlite:distro:sys"
+      "sqlite:distro:sys",
+      "timer:distro:sys"
     ],
     "grant_capabilities": [
       "homepage:homepage:sys",
@@ -38,7 +39,8 @@
       "vfs:distro:sys",
       "terminal:terminal:sys",
       "eth:distro:sys",
-      "sqlite:distro:sys"
+      "sqlite:distro:sys",
+      "timer:distro:sys"
     ],
     "public": false
   }

--- a/provider/metadata.json
+++ b/provider/metadata.json
@@ -5,7 +5,7 @@
   "properties": {
     "package_name": "hypergrid",
     "current_version": "0.1.0",
-    "publisher": "ware.hypr",
+    "publisher": "test.hypr",
     "mirrors": [],
     "code_hashes": {
       "0.1.0": ""

--- a/provider/pkg/manifest.json
+++ b/provider/pkg/manifest.json
@@ -9,7 +9,8 @@
       "http-client:distro:sys",
       "http-server:distro:sys",
       "vfs:distro:sys",
-      "eth:distro:sys"
+      "eth:distro:sys",
+      "timer:distro:sys"
     ],
     "grant_capabilities": [
       "homepage:homepage:sys",
@@ -17,7 +18,8 @@
       "http-server:distro:sys",
       "vfs:distro:sys",
       "terminal:terminal:sys",
-      "eth:distro:sys"
+      "eth:distro:sys",
+      "timer:distro:sys"
     ],
     "public": false
   }

--- a/provider/provider/Cargo.toml
+++ b/provider/provider/Cargo.toml
@@ -2,6 +2,7 @@
 anyhow = "1.0.97"
 base64ct = "=1.6.0"
 process_macros = "0.1"
+regex = "1"
 rmp-serde = "1.3.0"
 serde_json = "1.0"
 url = "2.5.4"

--- a/provider/provider/src/curl_executor.rs
+++ b/provider/provider/src/curl_executor.rs
@@ -1,0 +1,188 @@
+use hyperware_app_common::hyperware_process_lib::{
+    http::{
+        client::{HttpClientError},
+        Method as HyperwareHttpMethod,
+        Response as HyperwareHttpResponse,
+    },
+    logging::{debug, error, info},
+};
+use regex::Regex;
+use std::collections::HashMap;
+use url::Url;
+
+use crate::util::send_async_http_request;
+
+#[derive(Debug, Clone)]
+pub struct ParsedCurl {
+    pub method: HyperwareHttpMethod,
+    pub url: Url,
+    pub headers: HashMap<String, String>,
+    pub body: Vec<u8>,
+}
+
+/// Parse a curl command into its components
+pub fn parse_curl_command(curl_command: &str) -> Result<ParsedCurl, String> {
+    debug!("Parsing curl command: {}", curl_command);
+    
+    // Extract method (-X or --request)
+    let method_regex = Regex::new(r"(?i)-X\s+([A-Z]+)|--request\s+([A-Z]+)")
+        .map_err(|e| format!("Failed to compile method regex: {}", e))?;
+    
+    let method = if let Some(captures) = method_regex.captures(curl_command) {
+        let method_str = captures.get(1)
+            .or(captures.get(2))
+            .map(|m| m.as_str())
+            .unwrap_or("GET");
+        
+        match method_str.to_uppercase().as_str() {
+            "GET" => HyperwareHttpMethod::GET,
+            "POST" => HyperwareHttpMethod::POST,
+            "PUT" => HyperwareHttpMethod::PUT,
+            "DELETE" => HyperwareHttpMethod::DELETE,
+            "PATCH" => HyperwareHttpMethod::PATCH,
+            "HEAD" => HyperwareHttpMethod::HEAD,
+            _ => return Err(format!("Unsupported HTTP method: {}", method_str)),
+        }
+    } else if curl_command.contains("-d ") || curl_command.contains("--data") {
+        // If no explicit method but has data, assume POST
+        HyperwareHttpMethod::POST
+    } else {
+        HyperwareHttpMethod::GET
+    };
+    
+    // Extract headers (-H or --header)
+    let header_regex = Regex::new(r#"(?i)(?:-H|--header)\s+["']([^"']+)["']"#)
+        .map_err(|e| format!("Failed to compile header regex: {}", e))?;
+    
+    let mut headers = HashMap::new();
+    for captures in header_regex.captures_iter(curl_command) {
+        if let Some(header_str) = captures.get(1) {
+            let header_content = header_str.as_str();
+            if let Some(colon_pos) = header_content.find(':') {
+                let key = header_content[..colon_pos].trim().to_string();
+                let value = header_content[colon_pos + 1..].trim().to_string();
+                headers.insert(key, value);
+            }
+        }
+    }
+    
+    // Extract body/data (-d or --data)
+    let data_regex = Regex::new(r#"(?i)(?:-d|--data)\s+(?:["']([^"']+)["']|([^\s]+))"#)
+        .map_err(|e| format!("Failed to compile data regex: {}", e))?;
+    
+    let body = if let Some(captures) = data_regex.captures(curl_command) {
+        let data_str = captures.get(1)
+            .or(captures.get(2))
+            .map(|m| m.as_str())
+            .unwrap_or("");
+        data_str.as_bytes().to_vec()
+    } else {
+        Vec::new()
+    };
+    
+    // Extract URL (typically the last non-flag argument)
+    // First try to find URL in quotes
+    let url_quoted_regex = Regex::new(r#"["']([^"']*(?:https?://|/)[^"']*)["']"#)
+        .map_err(|e| format!("Failed to compile URL quoted regex: {}", e))?;
+    
+    // Then try without quotes
+    let url_unquoted_regex = Regex::new(r"(https?://[^\s]+)")
+        .map_err(|e| format!("Failed to compile URL unquoted regex: {}", e))?;
+    
+    let url_str = if let Some(captures) = url_quoted_regex.captures(curl_command) {
+        captures.get(1).map(|m| m.as_str()).unwrap_or("")
+    } else if let Some(captures) = url_unquoted_regex.captures(curl_command) {
+        captures.get(1).map(|m| m.as_str()).unwrap_or("")
+    } else {
+        return Err("No URL found in curl command".to_string());
+    };
+    
+    let url = Url::parse(url_str)
+        .map_err(|e| format!("Failed to parse URL '{}': {}", url_str, e))?;
+    
+    Ok(ParsedCurl {
+        method,
+        url,
+        headers,
+        body,
+    })
+}
+
+/// Execute a curl template with variable substitution
+pub async fn execute_curl_template(
+    template: &str,
+    arguments: &Vec<(String, String)>,
+) -> Result<String, String> {
+    info!("Executing curl template with {} arguments", arguments.len());
+    
+    // Step 1: Variable substitution
+    let mut curl_command = template.to_string();
+    for (key, value) in arguments {
+        let placeholder = format!("{{{{{}}}}}", key);
+        debug!("Replacing {} with value", placeholder);
+        curl_command = curl_command.replace(&placeholder, value);
+    }
+    
+    // Check for any remaining placeholders
+    let remaining_placeholder_regex = Regex::new(r"\{\{[^}]+\}\}")
+        .map_err(|e| format!("Failed to compile placeholder regex: {}", e))?;
+    
+    if remaining_placeholder_regex.is_match(&curl_command) {
+        let missing_vars: Vec<String> = remaining_placeholder_regex
+            .find_iter(&curl_command)
+            .map(|m| m.as_str().to_string())
+            .collect();
+        return Err(format!(
+            "Missing values for variables: {}",
+            missing_vars.join(", ")
+        ));
+    }
+    
+    // Step 2: Parse curl command
+    let parsed = parse_curl_command(&curl_command)?;
+    
+    debug!(
+        "Parsed curl - Method: {:?}, URL: {}, Headers: {:?}, Body size: {}",
+        parsed.method,
+        parsed.url,
+        parsed.headers,
+        parsed.body.len()
+    );
+    
+    // Step 3: Execute using existing HTTP client
+    let response = send_async_http_request(
+        parsed.method,
+        parsed.url,
+        Some(parsed.headers),
+        60,
+        parsed.body,
+    )
+    .await
+    .map_err(|e| format!("HTTP request failed: {:?}", e))?;
+    
+    // Step 4: Format response
+    format_response(response)
+}
+
+/// Format HTTP response into a string
+pub fn format_response(response: HyperwareHttpResponse<Vec<u8>>) -> Result<String, String> {
+    let status = response.status();
+    let body_bytes = response.into_body();
+    
+    // Try to convert body to string
+    let body_str = String::from_utf8(body_bytes.clone())
+        .unwrap_or_else(|_| {
+            // If not valid UTF-8, return base64 encoded
+            format!("[Binary data, {} bytes]", body_bytes.len())
+        });
+    
+    if status.is_success() {
+        Ok(body_str)
+    } else {
+        Err(format!(
+            "HTTP request failed with status {}: {}",
+            status.as_u16(),
+            body_str
+        ))
+    }
+}

--- a/provider/provider/src/lib.rs
+++ b/provider/provider/src/lib.rs
@@ -26,6 +26,9 @@ use util::*; // Use its public items
 mod db; // Declare the db module  
 use db::*; // Use its public items
 
+mod curl_executor; // Declare the curl_executor module
+use curl_executor::*; // Use its public items
+
 pub mod constants; // Declare the constants module
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ProviderRequest {
@@ -51,14 +54,14 @@ pub struct ValidateAndRegisterRequest {
     pub validation_arguments: Vec<(String, String)>,
 }
 
-// Type system for API endpoints
+// Type system for API endpoints - kept for backward compatibility
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum HttpMethod {
     GET,
     POST,
 }
 
-// --- Added Enum for Request Structure ---
+// --- Added Enum for Request Structure - kept for backward compatibility ---
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub enum RequestStructureType {
     GetWithPath,
@@ -76,22 +79,19 @@ pub enum TerminalCommand {
     ViewDatabase,
 }
 
-// --- Modified EndpointDefinition ---
+// --- New Variable struct for curl templates ---
+#[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
+pub struct Variable {
+    pub name: String,
+    pub example_value: Option<String>,
+}
+
+// --- New EndpointDefinition with curl templates ---
 #[derive(PartialEq, Clone, Debug, Serialize, Deserialize)]
 pub struct EndpointDefinition {
-    pub name: String,                            // Operation name, e.g., "getUserById"
-    pub method: HttpMethod,                      // GET, POST
-    pub request_structure: RequestStructureType, // Explicitly define the structure
-    pub base_url_template: String, // e.g., "https://api.example.com/users/{id}" or "https://api.example.com/v{apiVersion}/users"
-    pub path_param_keys: Option<Vec<String>>, // Keys for placeholders in base_url_template, relevant for GetWithPath, PostWithJson
-    pub query_param_keys: Option<Vec<String>>, // Keys for dynamic query params, relevant for GetWithQuery, PostWithJson
-    pub header_keys: Option<Vec<String>>, // Keys for dynamic headers (always potentially relevant)
-    pub body_param_keys: Option<Vec<String>>, // Keys for dynamic body params, relevant for PostWithJson
-
-    pub api_key: Option<String>, // The actual secret key
-
-    pub api_key_query_param_name: Option<String>, // e.g., "api_key"
-    pub api_key_header_name: Option<String>,      // e.g., "X-API-Key"
+    pub name: String,
+    pub curl_template: String,
+    pub variables: Vec<Variable>,
 }
 
 // --- New Provider Struct ---

--- a/provider/ui/src/components/CurlImportModal.tsx
+++ b/provider/ui/src/components/CurlImportModal.tsx
@@ -1,14 +1,13 @@
 import React, { useState } from 'react';
 import Modal from './Modal';
-import { parseCurlCommand, curlToFormData } from '../utils/curlParser.ts';
-import type { CurlToFormMapping } from '../utils/curlParser.ts';
-import { FiCheckCircle, FiAlertTriangle, FiXCircle } from 'react-icons/fi';
+import { Variable } from '../types/hypergrid_provider';
+import { FiCheckCircle } from 'react-icons/fi';
 import { FaCopy } from 'react-icons/fa6';
 
 interface CurlImportModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onImport: (formData: Partial<CurlToFormMapping>) => void;
+  onImport: (template: string, variables: Variable[]) => void;
 }
 
 const CurlImportModal: React.FC<CurlImportModalProps> = ({
@@ -17,294 +16,94 @@ const CurlImportModal: React.FC<CurlImportModalProps> = ({
   onImport
 }) => {
   const [curlInput, setCurlInput] = useState('');
-  const [parseResult, setParseResult] = useState<CurlToFormMapping | null>(null);
-  const [showPreview, setShowPreview] = useState(false);
-
-  const handleParseCurl = () => {
-    if (!curlInput.trim()) return;
-    
-    const parsed = parseCurlCommand(curlInput.trim());
-    const formMapping = curlToFormData(parsed);
-    setParseResult(formMapping);
-    setShowPreview(true);
-  };
 
   const handleImport = () => {
-    if (!parseResult) return;
+    const trimmedCurl = curlInput.trim();
+    if (!trimmedCurl) {
+      alert('Please enter a curl command');
+      return;
+    }
     
-    // Convert to the format expected by the form
-    const formData: Partial<CurlToFormMapping> = {
-      endpointBaseUrl: parseResult.endpointBaseUrl,
-      topLevelRequestType: parseResult.topLevelRequestType,
-      pathParamKeys: parseResult.pathParamKeys,
-      queryParamKeys: parseResult.queryParamKeys,
-      headerKeys: parseResult.headerKeys,
-      bodyKeys: parseResult.bodyKeys,
-      endpointApiParamKey: parseResult.endpointApiParamKey,
-      authChoice: parseResult.authChoice,
-      apiKeyQueryParamName: parseResult.apiKeyQueryParamName,
-      apiKeyHeaderName: parseResult.apiKeyHeaderName,
-    };
-    
-    onImport(formData);
+    // Simply pass the curl command as-is
+    // Variables will be selected later in the CurlTemplateEditor
+    onImport(trimmedCurl, []);
     handleClose();
   };
 
   const handleClose = () => {
     setCurlInput('');
-    setParseResult(null);
-    setShowPreview(false);
     onClose();
   };
 
   const exampleCurl = `curl -X GET \\
   -H "X-API-Key: your-api-key" \\
   -H "Content-Type: application/json" \\
-  "https://api.example.com/v1/users/123/profile?include=email&format=json"`;
+  https://api.example.com/v1/data`;
 
   if (!isOpen) return null;
 
   return (
-    <Modal title="Import from Curl Command" onClose={handleClose}>
-      <div className="max-w-4xl mx-auto">
-        {!showPreview ? (
-          // Step 1: Curl Input
-          <div className="flex flex-col gap-6">
-            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
-              <div className="flex items-start gap-3">
-                <FiCheckCircle className="text-blue-600 mt-0.5 flex-shrink-0" />
-                <div>
-                  <h4 className="font-medium text-blue-900">How to use Curl Import</h4>
-                  <p className="text-sm text-blue-700 mt-1">
-                    Paste a curl command below and we'll automatically extract the API configuration. 
-                    This works best with standard REST APIs using GET or POST methods.
-                  </p>
-                </div>
+    <Modal title="Import from Curl" onClose={handleClose}>
+      <div className="max-w-3xl">
+        <div className="flex flex-col gap-6">
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+            <div className="flex items-start gap-3">
+              <FiCheckCircle className="text-blue-600 mt-0.5 flex-shrink-0" />
+              <div>
+                <h4 className="font-medium text-blue-900">Import Curl Command</h4>
+                <p className="text-sm text-blue-700 mt-1">
+                  Paste a curl command below to use it as a template. 
+                  After importing, you can select parts of the command to turn into variables.
+                </p>
               </div>
-            </div>
-
-            <div className="flex flex-col gap-2">
-              <label htmlFor="curl-input" className="text-sm font-medium text-gray-700">
-                Curl Command
-              </label>
-              <textarea
-                id="curl-input"
-                value={curlInput}
-                onChange={(e) => setCurlInput(e.target.value)}
-                placeholder="Paste your curl command here..."
-                className="w-full h-32 p-3 border border-gray-300 rounded-lg font-mono text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
-            </div>
-
-            <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
-              <div className="flex items-center justify-between mb-2">
-                <h5 className="text-sm font-medium text-gray-700">Example:</h5>
-                <button
-                  onClick={() => setCurlInput(exampleCurl)}
-                  className="text-xs bg-gray-200 hover:bg-gray-300 px-2 py-1 rounded flex items-center gap-1"
-                >
-                  <FaCopy className="text-xs" />
-                  Use Example
-                </button>
-              </div>
-              <pre className="text-xs text-gray-600 overflow-x-auto">
-                <code>{exampleCurl}</code>
-              </pre>
-            </div>
-
-            <div className="flex gap-3 pt-4 border-t">
-              <button
-                onClick={handleParseCurl}
-                disabled={!curlInput.trim()}
-                className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed"
-              >
-                Parse Curl Command
-              </button>
-              <button
-                onClick={handleClose}
-                className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300"
-              >
-                Cancel
-              </button>
             </div>
           </div>
-        ) : (
-          // Step 2: Preview Results
-          <div className="flex flex-col gap-6">
-            <div className="flex items-center justify-between">
-              <h3 className="text-lg font-medium">Import Preview</h3>
-              <button
-                onClick={() => setShowPreview(false)}
-                className="text-sm text-blue-600 hover:text-blue-800"
-              >
-                ← Edit Curl Command
-              </button>
-            </div>
 
-            {parseResult?.warnings && parseResult.warnings.length > 0 && (
-              <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-                <div className="flex items-start gap-3">
-                  <FiAlertTriangle className="text-yellow-600 mt-0.5 flex-shrink-0" />
-                  <div>
-                    <h4 className="font-medium text-yellow-900">Parsing Warnings</h4>
-                    <ul className="text-sm text-yellow-700 mt-1 list-disc list-inside">
-                      {parseResult.warnings.map((warning, index) => (
-                        <li key={index}>{warning}</li>
-                      ))}
-                    </ul>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            {parseResult && (
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                {/* Basic Configuration */}
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <h4 className="font-medium text-gray-900 mb-3">Basic Configuration</h4>
-                  <div className="space-y-3 text-sm">
-                    <div>
-                      <span className="text-gray-600">Request Type:</span>
-                      <span className="ml-2 font-mono bg-white px-2 py-1 rounded">
-                        {parseResult.topLevelRequestType === 'getWithPath' ? 'GET with Path Parameters' :
-                         parseResult.topLevelRequestType === 'getWithQuery' ? 'GET with Query Parameters' :
-                         'POST with JSON Body'}
-                      </span>
-                    </div>
-                    <div>
-                      <span className="text-gray-600">Base URL:</span>
-                      <div className="mt-1 font-mono bg-white px-2 py-1 rounded text-xs break-all">
-                        {parseResult.endpointBaseUrl}
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Authentication */}
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <h4 className="font-medium text-gray-900 mb-3">Authentication</h4>
-                  <div className="space-y-3 text-sm">
-                    <div>
-                      <span className="text-gray-600">API Key Location:</span>
-                      <span className="ml-2 font-mono bg-white px-2 py-1 rounded">
-                        {parseResult.authChoice === 'header' ? 'Header' :
-                         parseResult.authChoice === 'query' ? 'Query Parameter' :
-                         'None detected'}
-                      </span>
-                    </div>
-                    {parseResult.authChoice === 'header' && parseResult.apiKeyHeaderName && (
-                      <div>
-                        <span className="text-gray-600">Header Name:</span>
-                        <span className="ml-2 font-mono bg-white px-2 py-1 rounded text-xs">
-                          {parseResult.apiKeyHeaderName}
-                        </span>
-                      </div>
-                    )}
-                    {parseResult.authChoice === 'query' && parseResult.apiKeyQueryParamName && (
-                      <div>
-                        <span className="text-gray-600">Query Param:</span>
-                        <span className="ml-2 font-mono bg-white px-2 py-1 rounded text-xs">
-                          {parseResult.apiKeyQueryParamName}
-                        </span>
-                      </div>
-                    )}
-                    {parseResult.endpointApiParamKey && (
-                      <div>
-                        <span className="text-gray-600">API Key:</span>
-                        <span className="ml-2 font-mono bg-white px-2 py-1 rounded text-xs">
-                          {parseResult.endpointApiParamKey.substring(0, 8)}...
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                </div>
-
-                {/* Parameters */}
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <h4 className="font-medium text-gray-900 mb-3">Parameters</h4>
-                  <div className="space-y-3 text-sm">
-                    {parseResult.pathParamKeys.length > 0 && (
-                      <div>
-                        <span className="text-gray-600">Path Parameters:</span>
-                        <div className="mt-1 flex flex-wrap gap-1">
-                          {parseResult.pathParamKeys.map((key, index) => (
-                            <span key={index} className="font-mono bg-white px-2 py-1 rounded text-xs">
-                              {key}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                    {parseResult.queryParamKeys.length > 0 && (
-                      <div>
-                        <span className="text-gray-600">Query Parameters:</span>
-                        <div className="mt-1 flex flex-wrap gap-1">
-                          {parseResult.queryParamKeys.map((key, index) => (
-                            <span key={index} className="font-mono bg-white px-2 py-1 rounded text-xs">
-                              {key}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                    {parseResult.headerKeys.length > 0 && (
-                      <div>
-                        <span className="text-gray-600">Custom Headers:</span>
-                        <div className="mt-1 flex flex-wrap gap-1">
-                          {parseResult.headerKeys.map((key, index) => (
-                            <span key={index} className="font-mono bg-white px-2 py-1 rounded text-xs">
-                              {key}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                    {parseResult.bodyKeys.length > 0 && (
-                      <div>
-                        <span className="text-gray-600">JSON Body Keys:</span>
-                        <div className="mt-1 flex flex-wrap gap-1">
-                          {parseResult.bodyKeys.map((key, index) => (
-                            <span key={index} className="font-mono bg-white px-2 py-1 rounded text-xs">
-                              {key}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                </div>
-
-                {/* Summary */}
-                <div className="bg-green-50 border border-green-200 rounded-lg p-4">
-                  <div className="flex items-start gap-3">
-                    <FiCheckCircle className="text-green-600 mt-0.5 flex-shrink-0" />
-                    <div>
-                      <h4 className="font-medium text-green-900">Ready to Import</h4>
-                      <p className="text-sm text-green-700 mt-1">
-                        The curl command was successfully parsed. Click "Import Configuration" to populate the form with these settings.
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )}
-
-            <div className="flex gap-3 pt-4 border-t">
-              <button
-                onClick={handleImport}
-                className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700"
-              >
-                Import Configuration
-              </button>
-              <button
-                onClick={handleClose}
-                className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300"
-              >
-                Cancel
-              </button>
-            </div>
+          <div className="flex flex-col gap-2">
+            <label htmlFor="curl-input" className="text-sm font-medium text-gray-700">
+              Curl Command
+            </label>
+            <textarea
+              id="curl-input"
+              value={curlInput}
+              onChange={(e) => setCurlInput(e.target.value)}
+              placeholder="Paste your curl command here..."
+              className="w-full h-32 p-3 border border-gray-300 rounded-lg font-mono text-sm resize-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            />
           </div>
-        )}
+
+          <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+            <div className="flex items-center justify-between mb-2">
+              <h5 className="text-sm font-medium text-gray-700">Example:</h5>
+              <button
+                onClick={() => setCurlInput(exampleCurl)}
+                className="text-xs bg-gray-200 hover:bg-gray-300 px-2 py-1 rounded flex items-center gap-1"
+              >
+                <FaCopy className="text-xs" />
+                Use Example
+              </button>
+            </div>
+            <pre className="text-xs text-gray-600 overflow-x-auto">
+              <code>{exampleCurl}</code>
+            </pre>
+          </div>
+
+          <div className="flex gap-3 pt-4 border-t">
+            <button
+              onClick={handleImport}
+              disabled={!curlInput.trim()}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed"
+            >
+              Import Curl Command
+            </button>
+            <button
+              onClick={handleClose}
+              className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
       </div>
     </Modal>
   );

--- a/provider/ui/src/components/CurlTemplateEditor.tsx
+++ b/provider/ui/src/components/CurlTemplateEditor.tsx
@@ -1,0 +1,301 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { Variable } from '../types/hypergrid_provider';
+import { BsTrash, BsPencil, BsPlus, BsCheck, BsX } from 'react-icons/bs';
+
+interface CurlTemplateEditorProps {
+  value: string;
+  variables: Variable[];
+  onChange: (template: string, variables: Variable[]) => void;
+}
+
+const CurlTemplateEditor: React.FC<CurlTemplateEditorProps> = ({
+  value,
+  variables,
+  onChange,
+}) => {
+  const [template, setTemplate] = useState(value);
+  const [localVariables, setLocalVariables] = useState<Variable[]>(variables);
+  const [selection, setSelection] = useState<{ start: number; end: number; text: string } | null>(null);
+  const [creatingVariable, setCreatingVariable] = useState(false);
+  const [newVariableName, setNewVariableName] = useState('');
+  const [editingVariable, setEditingVariable] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState('');
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    setTemplate(value);
+  }, [value]);
+
+  useEffect(() => {
+    setLocalVariables(variables);
+  }, [variables]);
+
+  const handleTextSelection = () => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+
+    const start = textarea.selectionStart;
+    const end = textarea.selectionEnd;
+    const selectedText = textarea.value.substring(start, end);
+
+    if (selectedText.length > 0) {
+      setSelection({ start, end, text: selectedText });
+    } else {
+      setSelection(null);
+    }
+  };
+
+  const createVariable = () => {
+    if (!selection || !newVariableName.trim()) return;
+
+    // Replace selected text with {{variableName}}
+    const newTemplate = 
+      template.substring(0, selection.start) + 
+      `{{${newVariableName.trim()}}}` + 
+      template.substring(selection.end);
+
+    // Add to variables list
+    const newVariable: Variable = {
+      name: newVariableName.trim(),
+      example_value: selection.text,
+    };
+
+    const updatedVariables = [...localVariables, newVariable];
+    
+    setTemplate(newTemplate);
+    setLocalVariables(updatedVariables);
+    onChange(newTemplate, updatedVariables);
+    
+    // Reset state
+    setSelection(null);
+    setCreatingVariable(false);
+    setNewVariableName('');
+  };
+
+  const deleteVariable = (name: string) => {
+    // Remove from variables list
+    const updatedVariables = localVariables.filter(v => v.name !== name);
+    
+    // Optionally replace {{name}} back with example value in template
+    let updatedTemplate = template;
+    const variable = localVariables.find(v => v.name === name);
+    if (variable?.example_value) {
+      updatedTemplate = template.replace(new RegExp(`\\{\\{${name}\\}\\}`, 'g'), variable.example_value);
+    }
+    
+    setLocalVariables(updatedVariables);
+    setTemplate(updatedTemplate);
+    onChange(updatedTemplate, updatedVariables);
+  };
+
+  const renameVariable = (oldName: string, newName: string) => {
+    if (!newName.trim() || oldName === newName) {
+      setEditingVariable(null);
+      return;
+    }
+
+    // Update in variables list
+    const updatedVariables = localVariables.map(v => 
+      v.name === oldName ? { ...v, name: newName.trim() } : v
+    );
+    
+    // Update in template
+    const updatedTemplate = template.replace(
+      new RegExp(`\\{\\{${oldName}\\}\\}`, 'g'), 
+      `{{${newName.trim()}}}`
+    );
+    
+    setLocalVariables(updatedVariables);
+    setTemplate(updatedTemplate);
+    onChange(updatedTemplate, updatedVariables);
+    setEditingVariable(null);
+    setEditingName('');
+  };
+
+  const updateExampleValue = (name: string, exampleValue: string) => {
+    const updatedVariables = localVariables.map(v => 
+      v.name === name ? { ...v, example_value: exampleValue } : v
+    );
+    
+    setLocalVariables(updatedVariables);
+    onChange(template, updatedVariables);
+  };
+
+  const getPreview = () => {
+    let preview = template;
+    localVariables.forEach(variable => {
+      const placeholder = `{{${variable.name}}}`;
+      const value = variable.example_value || `<${variable.name}>`;
+      preview = preview.replace(new RegExp(placeholder.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), value);
+    });
+    return preview;
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Curl Template Input */}
+      <div>
+        <label className="block text-sm font-semibold text-dark-gray dark:text-gray mb-2">
+          Curl Template
+        </label>
+        <textarea
+          ref={textareaRef}
+          value={template}
+          onChange={(e) => {
+            setTemplate(e.target.value);
+            onChange(e.target.value, localVariables);
+          }}
+          onSelect={handleTextSelection}
+          className="w-full h-32 px-3 py-2 border border-gray-200 rounded-lg
+                   bg-white text-dark-gray dark:bg-black dark:text-gray
+                   font-mono text-sm resize-none
+                   focus:outline-none focus:ring-2 focus:ring-gray-900"
+          placeholder="curl https://api.example.com/v1/chat -H 'Authorization: Bearer sk-123' -d '{&quot;messages&quot;: []}''"
+        />
+        
+        {/* Variable Creation Button */}
+        {selection && !creatingVariable && (
+          <div className="mt-2">
+            <button
+              onClick={() => setCreatingVariable(true)}
+              className="px-3 py-1 bg-gray-900 text-white text-sm rounded-lg
+                       hover:bg-gray-800 transition-colors"
+            >
+              <BsPlus className="inline mr-1" />
+              Create Variable from Selection
+            </button>
+            <span className="ml-2 text-sm text-gray-500">
+              Selected: "{selection.text}"
+            </span>
+          </div>
+        )}
+
+        {/* Variable Name Input */}
+        {creatingVariable && selection && (
+          <div className="mt-2 flex items-center gap-2">
+            <input
+              type="text"
+              value={newVariableName}
+              onChange={(e) => setNewVariableName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') createVariable();
+                if (e.key === 'Escape') {
+                  setCreatingVariable(false);
+                  setNewVariableName('');
+                }
+              }}
+              placeholder="Variable name"
+              className="px-3 py-1 border border-gray-200 rounded-lg
+                       bg-white text-dark-gray dark:bg-black dark:text-gray
+                       text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
+              autoFocus
+            />
+            <button
+              onClick={createVariable}
+              className="p-1 text-green-600 hover:text-green-700"
+            >
+              <BsCheck className="text-xl" />
+            </button>
+            <button
+              onClick={() => {
+                setCreatingVariable(false);
+                setNewVariableName('');
+              }}
+              className="p-1 text-red-600 hover:text-red-700"
+            >
+              <BsX className="text-xl" />
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* Variables List */}
+      {localVariables.length > 0 && (
+        <div>
+          <label className="block text-sm font-semibold text-dark-gray dark:text-gray mb-2">
+            Variables
+          </label>
+          <div className="space-y-2">
+            {localVariables.map((variable) => (
+              <div key={variable.name} className="flex items-center gap-2 p-2 border border-gray-200 rounded-lg">
+                {editingVariable === variable.name ? (
+                  <>
+                    <input
+                      type="text"
+                      value={editingName}
+                      onChange={(e) => setEditingName(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') renameVariable(variable.name, editingName);
+                        if (e.key === 'Escape') setEditingVariable(null);
+                      }}
+                      className="px-2 py-1 border border-gray-200 rounded
+                               bg-white text-dark-gray dark:bg-black dark:text-gray
+                               text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
+                      autoFocus
+                    />
+                    <button
+                      onClick={() => renameVariable(variable.name, editingName)}
+                      className="p-1 text-green-600 hover:text-green-700"
+                    >
+                      <BsCheck />
+                    </button>
+                    <button
+                      onClick={() => setEditingVariable(null)}
+                      className="p-1 text-red-600 hover:text-red-700"
+                    >
+                      <BsX />
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <span className="font-mono text-sm font-semibold text-dark-gray dark:text-gray">
+                      {`{{${variable.name}}}`}
+                    </span>
+                    <input
+                      type="text"
+                      value={variable.example_value || ''}
+                      onChange={(e) => updateExampleValue(variable.name, e.target.value)}
+                      placeholder="Example value"
+                      className="flex-1 px-2 py-1 border border-gray-200 rounded
+                               bg-white text-dark-gray dark:bg-black dark:text-gray
+                               text-sm focus:outline-none focus:ring-2 focus:ring-gray-900"
+                    />
+                    <button
+                      onClick={() => {
+                        setEditingVariable(variable.name);
+                        setEditingName(variable.name);
+                      }}
+                      className="p-1 text-gray-600 hover:text-gray-700"
+                    >
+                      <BsPencil />
+                    </button>
+                    <button
+                      onClick={() => deleteVariable(variable.name)}
+                      className="p-1 text-red-600 hover:text-red-700"
+                    >
+                      <BsTrash />
+                    </button>
+                  </>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Preview */}
+      <div>
+        <label className="block text-sm font-semibold text-dark-gray dark:text-gray mb-2">
+          Preview with Example Values
+        </label>
+        <div className="p-3 bg-gray-50 dark:bg-gray-900 rounded-lg">
+          <pre className="text-green-600 dark:text-green-400 text-sm font-mono whitespace-pre-wrap">
+            {getPreview()}
+          </pre>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CurlTemplateEditor;

--- a/provider/ui/src/components/ValidationPanel.tsx
+++ b/provider/ui/src/components/ValidationPanel.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { RegisteredProvider } from '../types/hypergrid_provider';
-import { HttpMethod, RequestStructureType } from '../types/hypergrid_provider';
 import { validateProviderApi } from '../utils/api';
 
 interface ValidationPanelProps {
@@ -23,102 +22,30 @@ const ValidationPanel: React.FC<ValidationPanelProps> = ({
   const [validationArgs, setValidationArgs] = useState<ValidationArgs>({});
   const [isValidating, setIsValidating] = useState(false);
 
-  // Generate sample values for placeholders
-  const getSampleValue = (key: string, paramType: 'path' | 'query' | 'header' | 'body'): string => {
-    switch (paramType) {
-      case 'path':
-        return key === 'id' ? '123' : `sample_${key}`;
-      case 'query':
-        return key === 'limit' ? '10' : `sample_${key}`;
-      case 'header':
-        return key.toLowerCase().includes('version') ? '1.0' : `sample_${key}`;
-      case 'body':
-        return `sample_${key}`;
-      default:
-        return `sample_${key}`;
+  // Generate sample value for a variable
+  const getSampleValue = (variableName: string): string => {
+    const variable = provider.endpoint.variables.find(v => v.name === variableName);
+    if (variable?.example_value) {
+      return variable.example_value;
     }
+    // Default sample values based on common patterns
+    if (variableName.toLowerCase().includes('id')) return '123';
+    if (variableName.toLowerCase().includes('limit')) return '10';
+    if (variableName.toLowerCase().includes('version')) return '1.0';
+    return `sample_${variableName}`;
   };
 
   const generateCurlPreview = (): string => {
-    let url = provider.endpoint.base_url_template;
-    const queryParams: string[] = [];
-    const headers: string[] = [];
-    let bodyData: { [key: string]: string } = {};
-
-    switch (provider.endpoint.request_structure) {
-      case RequestStructureType.GetWithPath:
-        if (provider.endpoint.path_param_keys) {
-          provider.endpoint.path_param_keys.forEach(key => {
-            const value = validationArgs[key] || getSampleValue(key, 'path');
-            url = url.replace(`{${key}}`, value);
-          });
-        }
-        break;
-
-      case RequestStructureType.GetWithQuery:
-        if (provider.endpoint.query_param_keys) {
-          provider.endpoint.query_param_keys.forEach(key => {
-            const value = validationArgs[key] || getSampleValue(key, 'query');
-            queryParams.push(`${key}=${encodeURIComponent(value)}`);
-          });
-        }
-        break;
-
-      case RequestStructureType.PostWithJson:
-        if (provider.endpoint.path_param_keys) {
-          provider.endpoint.path_param_keys.forEach(key => {
-            const value = validationArgs[key] || getSampleValue(key, 'path');
-            url = url.replace(`{${key}}`, value);
-          });
-        }
-        if (provider.endpoint.query_param_keys) {
-          provider.endpoint.query_param_keys.forEach(key => {
-            const value = validationArgs[key] || getSampleValue(key, 'query');
-            queryParams.push(`${key}=${encodeURIComponent(value)}`);
-          });
-        }
-        if (provider.endpoint.body_param_keys) {
-          provider.endpoint.body_param_keys.forEach(key => {
-            bodyData[key] = validationArgs[key] || getSampleValue(key, 'body');
-          });
-        }
-        break;
-    }
-
-    if (provider.endpoint.api_key && provider.endpoint.api_key_query_param_name) {
-      queryParams.push(`${provider.endpoint.api_key_query_param_name}=${provider.endpoint.api_key.substring(0, 3)}...`);
-    }
-
-    if (provider.endpoint.method === HttpMethod.POST) {
-      headers.push('-H "Content-Type: application/json"');
-    }
-
-    if (provider.endpoint.header_keys) {
-      provider.endpoint.header_keys.forEach(key => {
-        const value = validationArgs[key] || getSampleValue(key, 'header');
-        headers.push(`-H "${key}: ${value}"`);
-      });
-    }
-
-    if (provider.endpoint.api_key && provider.endpoint.api_key_header_name) {
-      headers.push(`-H "${provider.endpoint.api_key_header_name}: ${provider.endpoint.api_key.substring(0, 3)}..."`);
-    }
-
-    const finalUrl = queryParams.length > 0 ? `${url}?${queryParams.join('&')}` : url;
-
-    let curlCommand = `curl -X ${provider.endpoint.method}`;
-
-    if (headers.length > 0) {
-      curlCommand += ` \\\n  ${headers.join(' \\\n  ')}`;
-    }
-
-    if (provider.endpoint.method === HttpMethod.POST && Object.keys(bodyData).length > 0) {
-      curlCommand += ` \\\n  -d '${JSON.stringify(bodyData)}'`;
-    }
-
-    curlCommand += ` \\\n  "${finalUrl}"`;
-
-    return curlCommand;
+    // Simple variable substitution on the curl template
+    let preview = provider.endpoint.curl_template;
+    
+    provider.endpoint.variables.forEach(variable => {
+      const value = validationArgs[variable.name] || getSampleValue(variable.name);
+      const placeholder = `{{${variable.name}}}`;
+      preview = preview.replace(new RegExp(placeholder.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), value);
+    });
+    
+    return preview;
   };
 
   const handleValidationArgChange = (key: string, value: string) => {
@@ -150,26 +77,7 @@ const ValidationPanel: React.FC<ValidationPanelProps> = ({
     }
   };
 
-  const getAllParamKeysWithTypes = (): Array<{ key: string; type: 'path' | 'query' | 'header' | 'body' }> => {
-    const params: Array<{ key: string; type: 'path' | 'query' | 'header' | 'body' }> = [];
-
-    if (provider.endpoint.path_param_keys) {
-      provider.endpoint.path_param_keys.forEach(key => params.push({ key, type: 'path' }));
-    }
-    if (provider.endpoint.query_param_keys) {
-      provider.endpoint.query_param_keys.forEach(key => params.push({ key, type: 'query' }));
-    }
-    if (provider.endpoint.header_keys) {
-      provider.endpoint.header_keys.forEach(key => params.push({ key, type: 'header' }));
-    }
-    if (provider.endpoint.body_param_keys && provider.endpoint.method === HttpMethod.POST) {
-      provider.endpoint.body_param_keys.forEach(key => params.push({ key, type: 'body' }));
-    }
-
-    return params;
-  };
-
-  const allParams = getAllParamKeysWithTypes();
+  const variables = provider.endpoint.variables || [];
 
   return (
     <div className="flex flex-col">
@@ -184,25 +92,25 @@ const ValidationPanel: React.FC<ValidationPanelProps> = ({
       {/* Main Content */}
       <div className="flex flex-col items-center space-y-6">
         {/* Test Parameters Section */}
-        {allParams.length > 0 && (
+        {variables.length > 0 && (
           <div className="w-full max-w-xl">
             <div className="bg-gradient-to-b from-gray-50 to-white dark:to-black border border-gray-200 rounded-xl shadow-md p-6">
               <h3 className="text-lg font-bold text-dark-gray dark:text-gray text-center mb-6">Test Parameters</h3>
-              <div className={allParams.length === 1 ? "flex justify-center" : "grid grid-cols-1 md:grid-cols-2 gap-4"}>
-                {allParams.map(({ key, type }) => (
-                  <div key={key} className={allParams.length === 1 ? "w-full max-w-xs" : "group"}>
+              <div className={variables.length === 1 ? "flex justify-center" : "grid grid-cols-1 md:grid-cols-2 gap-4"}>
+                {variables.map((variable) => (
+                  <div key={variable.name} className={variables.length === 1 ? "w-full max-w-xs" : "group"}>
                     <label
-                      htmlFor={`validation-${key}`}
+                      htmlFor={`validation-${variable.name}`}
                       className="block text-sm font-semibold text-dark-gray dark:text-gray mb-1.5 text-center"
                     >
-                      {key} <span className="text-dark-gray dark:text-gray font-normal">({type})</span>
+                      {variable.name}
                     </label>
                     <input
-                      id={`validation-${key}`}
+                      id={`validation-${variable.name}`}
                       type="text"
-                      value={validationArgs[key] || ''}
-                      onChange={(e) => handleValidationArgChange(key, e.target.value)}
-                      placeholder={getSampleValue(key, type)}
+                      value={validationArgs[variable.name] || ''}
+                      onChange={(e) => handleValidationArgChange(variable.name, e.target.value)}
+                      placeholder={variable.example_value || getSampleValue(variable.name)}
                       className="w-full px-4 py-2.5 text-center border border-gray-200 rounded-lg
                                bg-white text-dark-gray dark:bg-black dark:text-gray
                                 transition-all duration-200

--- a/provider/ui/src/types/hypergrid_provider.ts
+++ b/provider/ui/src/types/hypergrid_provider.ts
@@ -5,35 +5,30 @@ interface RustResponse<T> {
   Err?: string;
 }
 
-// Enum for HTTP methods, matching Rust's HttpMethod
+// Enum for HTTP methods, matching Rust's HttpMethod - kept for backward compatibility
 export enum HttpMethod {
   GET = "GET",
   POST = "POST",
 }
 
-// --- Added Enum for Request Structure (Matches Rust) ---
+// --- Added Enum for Request Structure (Matches Rust) - kept for backward compatibility ---
 export enum RequestStructureType {
   GetWithPath = "GetWithPath",
   GetWithQuery = "GetWithQuery",
   PostWithJson = "PostWithJson",
 }
 
+// Interface for Variable, matching Rust's struct
+export interface Variable {
+  name: string;
+  example_value?: string;
+}
+
 // Interface for EndpointDefinition, matching Rust's struct
 export interface EndpointDefinition {
   name: string;
-  method: HttpMethod;
-  request_structure: RequestStructureType; // Added field
-  base_url_template: string;
-  path_param_keys?: string[]; // Changed to optional
-  query_param_keys?: string[]; // Changed to optional
-  header_keys?: string[];      // Changed to optional
-  body_param_keys?: string[];
-
-  api_key?: string;
-
-  // API Key Authentication
-  api_key_query_param_name?: string;
-  api_key_header_name?: string;
+  curl_template: string;
+  variables: Variable[];
 }
 
 // Interface for RegisteredProvider, matching Rust's struct

--- a/provider/ui/src/utils/providerFormUtils.ts
+++ b/provider/ui/src/utils/providerFormUtils.ts
@@ -1,266 +1,88 @@
-import { HttpMethod, EndpointDefinition, RegisteredProvider, RegisterProviderResponse, RequestStructureType, UpdateProviderResponse } from '../types/hypergrid_provider';
-import { TopLevelRequestType, AuthChoice } from '../types/hypergrid_provider';
+import { RegisteredProvider, Variable } from '../types/hypergrid_provider';
 
-// Interface for the data object passed to utility functions
-// This collects all relevant form state needed by the utils
-export interface ProviderFormData {
-  providerName: string;
-  providerDescription: string;
-  providerId: string;
-  instructions: string;
-  registeredProviderWallet: string;
-  price: string;
-  topLevelRequestType: TopLevelRequestType;
-  endpointBaseUrl: string;
-  pathParamKeys: string[];
-  queryParamKeys: string[];
-  headerKeys: string[];
-  bodyKeys: string[];
-  endpointApiParamKey: string;
-  authChoice: AuthChoice;
-  apiKeyQueryParamName: string;
-  apiKeyHeaderName: string;
-}
-
-// New types for smart update system
-export interface UpdateDetectionResult {
-  hasOnChainChanges: boolean;
-  hasOffChainChanges: boolean;
-  hasConfigChanges: boolean;
-  onChainChanges: Array<{ key: string; oldValue: string; newValue: string }>;
-  offChainChanges: Array<{ field: string; oldValue: any; newValue: any }>;
-  configChanges: Array<{ field: string; oldValue: any; newValue: any }>;
-}
-
-export interface SmartUpdatePlan {
-  needsOnChainUpdate: boolean;
-  needsOffChainUpdate: boolean;
-  shouldWarnAboutInstructions: boolean;
-  onChainNotes: Array<{ key: string; value: string }>;
-  updatedProvider: RegisteredProvider;
-}
-
-// On-chain note keys (must match the ones in hypermap.ts)
-export const ON_CHAIN_NOTE_KEYS = {
-  PROVIDER_ID: '~provider-id',
-  WALLET: '~wallet', 
-  DESCRIPTION: '~description',
-  INSTRUCTIONS: '~instructions',
-  PRICE: '~price',
-} as const;
-
-// Fields that affect API configuration and might require instruction updates
-const CONFIG_FIELDS = [
-  'topLevelRequestType',
-  'endpointBaseUrl', 
-  'pathParamKeys',
-  'queryParamKeys',
-  'headerKeys',
-  'bodyKeys',
-  'endpointApiParamKey',
-  'authChoice',
-  'apiKeyQueryParamName',
-  'apiKeyHeaderName'
-] as const;
-
-/**
- * Analyzes what changed between original and updated provider data
- */
-export function detectProviderChanges(
-  originalProvider: RegisteredProvider,
-  formData: ProviderFormData
-): UpdateDetectionResult {
-  const onChainChanges: Array<{ key: string; oldValue: string; newValue: string }> = [];
-  const offChainChanges: Array<{ field: string; oldValue: any; newValue: any }> = [];
-  const configChanges: Array<{ field: string; oldValue: any; newValue: any }> = [];
-
-  // Check on-chain fields
-  if (originalProvider.provider_id !== formData.providerId) {
-    onChainChanges.push({
-      key: ON_CHAIN_NOTE_KEYS.PROVIDER_ID,
-      oldValue: originalProvider.provider_id,
-      newValue: formData.providerId
-    });
+// Simple validation for provider configuration
+export function validateProviderConfig(provider: RegisteredProvider): { isValid: boolean; error?: string } {
+  if (!provider.provider_name.trim() || !provider.endpoint.curl_template.trim()) {
+    return { isValid: false, error: "Provider Name and Curl Template are required." };
   }
-
-  if (originalProvider.registered_provider_wallet !== formData.registeredProviderWallet.trim()) {
-    onChainChanges.push({
-      key: ON_CHAIN_NOTE_KEYS.WALLET,
-      oldValue: originalProvider.registered_provider_wallet,
-      newValue: formData.registeredProviderWallet.trim()
-    });
-  }
-
-  if (originalProvider.description !== formData.providerDescription) {
-    onChainChanges.push({
-      key: ON_CHAIN_NOTE_KEYS.DESCRIPTION,
-      oldValue: originalProvider.description,
-      newValue: formData.providerDescription
-    });
-  }
-
-  if (originalProvider.instructions !== formData.instructions) {
-    onChainChanges.push({
-      key: ON_CHAIN_NOTE_KEYS.INSTRUCTIONS,
-      oldValue: originalProvider.instructions,
-      newValue: formData.instructions
-    });
-  }
-
-  const newPrice = parseFloat(formData.price) || 0;
-  if (originalProvider.price !== newPrice) {
-    onChainChanges.push({
-      key: ON_CHAIN_NOTE_KEYS.PRICE,
-      oldValue: originalProvider.price.toString(),
-      newValue: newPrice.toString()
-    });
-  }
-
-  // Check off-chain fields (provider name)
-  if (originalProvider.provider_name !== formData.providerName) {
-    offChainChanges.push({
-      field: 'provider_name',
-      oldValue: originalProvider.provider_name,
-      newValue: formData.providerName
-    });
-  }
-
-  // Check endpoint configuration fields
-  const originalFormData = populateFormFromProvider(originalProvider);
   
-  CONFIG_FIELDS.forEach(field => {
-    const oldValue = originalFormData[field];
-    const newValue = formData[field];
-    
-    // Handle array comparison
-    if (Array.isArray(oldValue) && Array.isArray(newValue)) {
-      if (JSON.stringify(oldValue.sort()) !== JSON.stringify(newValue.sort())) {
-        configChanges.push({ field, oldValue, newValue });
-      }
-    } else if (oldValue !== newValue) {
-      configChanges.push({ field, oldValue, newValue });
-    }
-  });
-
-  return {
-    hasOnChainChanges: onChainChanges.length > 0,
-    hasOffChainChanges: offChainChanges.length > 0,
-    hasConfigChanges: configChanges.length > 0,
-    onChainChanges,
-    offChainChanges,
-    configChanges
-  };
-}
-
-/**
- * Creates a smart update plan based on detected changes
- */
-export function createSmartUpdatePlan(
-  originalProvider: RegisteredProvider,
-  formData: ProviderFormData
-): SmartUpdatePlan {
-  const changes = detectProviderChanges(originalProvider, formData);
-  const updatedProvider = buildUpdateProviderPayload(formData);
-
-  return {
-    needsOnChainUpdate: changes.hasOnChainChanges,
-    needsOffChainUpdate: changes.hasOffChainChanges || changes.hasConfigChanges || changes.hasOnChainChanges, // Also update backend when on-chain data changes
-    shouldWarnAboutInstructions: changes.hasConfigChanges && !changes.onChainChanges.some(c => c.key === ON_CHAIN_NOTE_KEYS.INSTRUCTIONS),
-    onChainNotes: changes.onChainChanges.map(change => ({
-      key: change.key,
-      value: change.newValue
-    })),
-    updatedProvider
-  };
-}
-
-interface ValidationResult {
-  isValid: boolean;
-  error?: string;
-}
-
-// New interface for API response feedback
-export interface ApiResponseFeedback {
-  status: 'success' | 'error' | 'info';
-  message: string;
-}
-
-export function validateProviderConfig(data: ProviderFormData): ValidationResult {
-  if (!data.providerName.trim() || !data.endpointBaseUrl.trim()) {
-    return { isValid: false, error: "Provider Name and Base URL Template are required." };
+  if (!provider.registered_provider_wallet.trim()) {
+    return { isValid: false, error: "Provider wallet address is required." };
   }
-  if (data.endpointApiParamKey.trim() && data.authChoice === 'query' && !data.apiKeyQueryParamName.trim()) {
-    return { isValid: false, error: "API Key Query Parameter Name is required when API Key is provided and auth method is Query." };
-  }
-  if (data.endpointApiParamKey.trim() && data.authChoice === 'header' && !data.apiKeyHeaderName.trim()) {
-    return { isValid: false, error: "API Key Header Name is required when API Key is provided and auth method is Header." };
-  }
-  // Add any other general validations if needed
+  
   return { isValid: true };
 }
 
-export function buildProviderPayload(data: ProviderFormData): { RegisterProvider: RegisteredProvider } {
-  const finalEndpointName = data.providerName.trim();
-
-  let derivedHttpMethod: HttpMethod;
-  let requestStructure: RequestStructureType;
-
-  switch (data.topLevelRequestType) {
-    case "getWithPath":
-      derivedHttpMethod = HttpMethod.GET;
-      requestStructure = RequestStructureType.GetWithPath;
-      break;
-    case "getWithQuery":
-      derivedHttpMethod = HttpMethod.GET;
-      requestStructure = RequestStructureType.GetWithQuery;
-      break;
-    case "postWithJson":
-      derivedHttpMethod = HttpMethod.POST;
-      requestStructure = RequestStructureType.PostWithJson;
-      break;
-    default:
-      // Fallback or error - should ideally not happen with UI validation
-      console.error("Invalid topLevelRequestType in buildProviderPayload!");
-      // Defaulting - consider throwing an error or using a default structure type
-      derivedHttpMethod = HttpMethod.GET; 
-      requestStructure = RequestStructureType.GetWithQuery; // Arbitrary default
-      break;
-  }
-
-  const pathKeys = data.pathParamKeys.filter(k => k.trim());
-  const queryKeys = data.queryParamKeys.filter(k => k.trim());
-  const headerKeys = data.headerKeys.filter(k => k.trim());
-  const bodyKeys = data.topLevelRequestType === "postWithJson" ? data.bodyKeys.filter(k => k.trim()) : [];
-
-  const endpointDef: EndpointDefinition = {
-    name: finalEndpointName,
-    method: derivedHttpMethod,
-    request_structure: requestStructure,
-    base_url_template: data.endpointBaseUrl,
-    path_param_keys: pathKeys.length > 0 ? pathKeys : undefined,
-    query_param_keys: queryKeys.length > 0 ? queryKeys : undefined,
-    header_keys: headerKeys.length > 0 ? headerKeys : undefined,
-    body_param_keys: bodyKeys.length > 0 ? bodyKeys : undefined,
-    api_key: data.endpointApiParamKey.trim() || undefined,
-    api_key_query_param_name: data.authChoice === 'query' && data.apiKeyQueryParamName.trim() ? data.apiKeyQueryParamName.trim() : undefined,
-    api_key_header_name: data.authChoice === 'header' && data.apiKeyHeaderName.trim() ? data.apiKeyHeaderName.trim() : undefined,
+// Build provider payload from form data
+export function buildProviderPayload(
+  providerName: string,
+  providerDescription: string,
+  providerId: string,
+  instructions: string,
+  registeredProviderWallet: string,
+  price: string,
+  curlTemplate: string,
+  variables: Variable[]
+): { RegisterProvider: RegisteredProvider } {
+  const provider: RegisteredProvider = {
+    provider_name: providerName.trim(),
+    provider_id: providerId,
+    description: providerDescription,
+    instructions: instructions,
+    registered_provider_wallet: registeredProviderWallet.trim(),
+    price: parseFloat(price) || 0,
+    endpoint: {
+      name: providerName.trim(),
+      curl_template: curlTemplate,
+      variables: variables
+    }
   };
 
-  const providerToRegister: RegisteredProvider = {
-    provider_name: data.providerName,
-    provider_id: data.providerId,
-    description: data.providerDescription,
-    instructions: data.instructions || "",
-    registered_provider_wallet: data.registeredProviderWallet.trim(),
-    price: parseFloat(data.price) || 0,
-    endpoint: endpointDef,
-  };
-
-  return { RegisterProvider: providerToRegister };
+  return { RegisterProvider: provider };
 }
 
-// New function to process API registration response
-export function processRegistrationResponse(response: RegisterProviderResponse): ApiResponseFeedback {
+// Build update provider payload
+export function buildUpdateProviderPayload(
+  providerName: string,
+  providerDescription: string,
+  providerId: string,
+  instructions: string,
+  registeredProviderWallet: string,
+  price: string,
+  curlTemplate: string,
+  variables: Variable[]
+): RegisteredProvider {
+  return {
+    provider_name: providerName.trim(),
+    provider_id: providerId,
+    description: providerDescription,
+    instructions: instructions,
+    registered_provider_wallet: registeredProviderWallet.trim(),
+    price: parseFloat(price) || 0,
+    endpoint: {
+      name: providerName.trim(),
+      curl_template: curlTemplate,
+      variables: variables
+    }
+  };
+}
+
+// Populate form data from an existing provider
+export function populateFormFromProvider(provider: RegisteredProvider) {
+  return {
+    providerName: provider.provider_name,
+    providerDescription: provider.description,
+    providerId: provider.provider_id,
+    instructions: provider.instructions,
+    registeredProviderWallet: provider.registered_provider_wallet,
+    price: provider.price.toString(),
+    curlTemplate: provider.endpoint.curl_template,
+    variables: provider.endpoint.variables
+  };
+}
+
+// Process registration response
+export function processRegistrationResponse(response: any) {
   if (response.Ok) {
     return { 
       status: 'success', 
@@ -279,108 +101,8 @@ export function processRegistrationResponse(response: RegisterProviderResponse):
   }
 }
 
-// Function to populate form data from an existing provider (for editing)
-export function populateFormFromProvider(provider: RegisteredProvider): Partial<ProviderFormData> {
-  // Convert the provider back to form data structure
-  let topLevelRequestType: TopLevelRequestType = 'getWithQuery'; // default
-  
-  if (provider.endpoint.request_structure === RequestStructureType.GetWithPath) {
-    topLevelRequestType = 'getWithPath';
-  } else if (provider.endpoint.request_structure === RequestStructureType.GetWithQuery) {
-    topLevelRequestType = 'getWithQuery';
-  } else if (provider.endpoint.request_structure === RequestStructureType.PostWithJson) {
-    topLevelRequestType = 'postWithJson';
-  }
-
-  // Determine auth choice based on which auth field is set
-  let authChoice: AuthChoice = 'none';
-  if (provider.endpoint.api_key_query_param_name) {
-    authChoice = 'query';
-  } else if (provider.endpoint.api_key_header_name) {
-    authChoice = 'header';
-  }
-
-  return {
-    providerName: provider.provider_name,
-    providerDescription: provider.description,
-    providerId: provider.provider_id,
-    instructions: provider.instructions,
-    registeredProviderWallet: provider.registered_provider_wallet,
-    price: provider.price.toString(),
-    topLevelRequestType,
-    endpointBaseUrl: provider.endpoint.base_url_template,
-    pathParamKeys: provider.endpoint.path_param_keys || [],
-    queryParamKeys: provider.endpoint.query_param_keys || [],
-    headerKeys: provider.endpoint.header_keys || [],
-    bodyKeys: provider.endpoint.body_param_keys || [],
-    endpointApiParamKey: provider.endpoint.api_key || '',
-    authChoice,
-    apiKeyQueryParamName: provider.endpoint.api_key_query_param_name || '',
-    apiKeyHeaderName: provider.endpoint.api_key_header_name || '',
-  };
-}
-
-// Function to build update payload (similar to register but for updates)
-export function buildUpdateProviderPayload(data: ProviderFormData): RegisteredProvider {
-  const finalEndpointName = data.providerName.trim();
-
-  let derivedHttpMethod: HttpMethod;
-  let requestStructure: RequestStructureType;
-
-  switch (data.topLevelRequestType) {
-    case "getWithPath":
-      derivedHttpMethod = HttpMethod.GET;
-      requestStructure = RequestStructureType.GetWithPath;
-      break;
-    case "getWithQuery":
-      derivedHttpMethod = HttpMethod.GET;
-      requestStructure = RequestStructureType.GetWithQuery;
-      break;
-    case "postWithJson":
-      derivedHttpMethod = HttpMethod.POST;
-      requestStructure = RequestStructureType.PostWithJson;
-      break;
-    default:
-      console.error("Invalid topLevelRequestType in buildUpdateProviderPayload!");
-      derivedHttpMethod = HttpMethod.GET; 
-      requestStructure = RequestStructureType.GetWithQuery;
-      break;
-  }
-
-  const pathKeys = data.pathParamKeys.filter(k => k.trim());
-  const queryKeys = data.queryParamKeys.filter(k => k.trim());
-  const headerKeys = data.headerKeys.filter(k => k.trim());
-  const bodyKeys = data.topLevelRequestType === "postWithJson" ? data.bodyKeys.filter(k => k.trim()) : [];
-
-  const endpointDef: EndpointDefinition = {
-    name: finalEndpointName,
-    method: derivedHttpMethod,
-    request_structure: requestStructure,
-    base_url_template: data.endpointBaseUrl,
-    path_param_keys: pathKeys.length > 0 ? pathKeys : undefined,
-    query_param_keys: queryKeys.length > 0 ? queryKeys : undefined,
-    header_keys: headerKeys.length > 0 ? headerKeys : undefined,
-    body_param_keys: bodyKeys.length > 0 ? bodyKeys : undefined,
-    api_key: data.endpointApiParamKey.trim() || undefined,
-    api_key_query_param_name: data.authChoice === 'query' && data.apiKeyQueryParamName.trim() ? data.apiKeyQueryParamName.trim() : undefined,
-    api_key_header_name: data.authChoice === 'header' && data.apiKeyHeaderName.trim() ? data.apiKeyHeaderName.trim() : undefined,
-  };
-
-  const updatedProvider: RegisteredProvider = {
-    provider_name: data.providerName,
-    provider_id: data.providerId, // This will be preserved by the backend
-    description: data.providerDescription,
-    instructions: data.instructions || "",
-    registered_provider_wallet: data.registeredProviderWallet.trim(),
-    price: parseFloat(data.price) || 0,
-    endpoint: endpointDef,
-  };
-
-  return updatedProvider;
-}
-
-// Function to process API update response
-export function processUpdateResponse(response: UpdateProviderResponse): ApiResponseFeedback {
+// Process update response
+export function processUpdateResponse(response: any) {
   if (response.Ok) {
     return { 
       status: 'success', 
@@ -397,4 +119,118 @@ export function processUpdateResponse(response: UpdateProviderResponse): ApiResp
       message: `Provider update submitted. Response structure unexpected: ${JSON.stringify(response)}` 
     };
   }
-} 
+}
+
+// Smart update detection for blockchain updates
+export interface UpdateDetectionResult {
+  hasOnChainChanges: boolean;
+  hasOffChainChanges: boolean;
+  onChainChanges: Array<{ key: string; oldValue: string; newValue: string }>;
+  offChainChanges: Array<{ field: string; oldValue: any; newValue: any }>;
+}
+
+export const ON_CHAIN_NOTE_KEYS = {
+  PROVIDER_ID: '~provider-id',
+  WALLET: '~wallet', 
+  DESCRIPTION: '~description',
+  INSTRUCTIONS: '~instructions',
+  PRICE: '~price',
+} as const;
+
+export function detectProviderChanges(
+  originalProvider: RegisteredProvider,
+  updatedProvider: RegisteredProvider
+): UpdateDetectionResult {
+  const onChainChanges: Array<{ key: string; oldValue: string; newValue: string }> = [];
+  const offChainChanges: Array<{ field: string; oldValue: any; newValue: any }> = [];
+
+  // Check on-chain fields
+  if (originalProvider.provider_id !== updatedProvider.provider_id) {
+    onChainChanges.push({
+      key: ON_CHAIN_NOTE_KEYS.PROVIDER_ID,
+      oldValue: originalProvider.provider_id,
+      newValue: updatedProvider.provider_id
+    });
+  }
+
+  if (originalProvider.registered_provider_wallet !== updatedProvider.registered_provider_wallet) {
+    onChainChanges.push({
+      key: ON_CHAIN_NOTE_KEYS.WALLET,
+      oldValue: originalProvider.registered_provider_wallet,
+      newValue: updatedProvider.registered_provider_wallet
+    });
+  }
+
+  if (originalProvider.description !== updatedProvider.description) {
+    onChainChanges.push({
+      key: ON_CHAIN_NOTE_KEYS.DESCRIPTION,
+      oldValue: originalProvider.description,
+      newValue: updatedProvider.description
+    });
+  }
+
+  if (originalProvider.instructions !== updatedProvider.instructions) {
+    onChainChanges.push({
+      key: ON_CHAIN_NOTE_KEYS.INSTRUCTIONS,
+      oldValue: originalProvider.instructions,
+      newValue: updatedProvider.instructions
+    });
+  }
+
+  if (originalProvider.price !== updatedProvider.price) {
+    onChainChanges.push({
+      key: ON_CHAIN_NOTE_KEYS.PRICE,
+      oldValue: originalProvider.price.toString(),
+      newValue: updatedProvider.price.toString()
+    });
+  }
+
+  // Check off-chain fields
+  if (originalProvider.provider_name !== updatedProvider.provider_name) {
+    offChainChanges.push({
+      field: 'provider_name',
+      oldValue: originalProvider.provider_name,
+      newValue: updatedProvider.provider_name
+    });
+  }
+
+  if (originalProvider.endpoint.curl_template !== updatedProvider.endpoint.curl_template) {
+    offChainChanges.push({
+      field: 'curl_template',
+      oldValue: originalProvider.endpoint.curl_template,
+      newValue: updatedProvider.endpoint.curl_template
+    });
+  }
+
+  if (JSON.stringify(originalProvider.endpoint.variables) !== JSON.stringify(updatedProvider.endpoint.variables)) {
+    offChainChanges.push({
+      field: 'variables',
+      oldValue: originalProvider.endpoint.variables,
+      newValue: updatedProvider.endpoint.variables
+    });
+  }
+
+  return {
+    hasOnChainChanges: onChainChanges.length > 0,
+    hasOffChainChanges: offChainChanges.length > 0,
+    onChainChanges,
+    offChainChanges
+  };
+}
+
+export function createSmartUpdatePlan(
+  originalProvider: RegisteredProvider,
+  updatedProvider: RegisteredProvider
+) {
+  const changes = detectProviderChanges(originalProvider, updatedProvider);
+
+  return {
+    needsOnChainUpdate: changes.hasOnChainChanges,
+    needsOffChainUpdate: changes.hasOffChainChanges || changes.hasOnChainChanges,
+    onChainNotes: changes.onChainChanges.map(change => ({
+      key: change.key,
+      value: change.newValue
+    })),
+    updatedProvider
+  };
+}


### PR DESCRIPTION
Opening this PR now so we can work from the same place if anybody is inclined to take a crack at it tomorrow morning while I'm flying (I cannot into streaming LLM tokens via plane wifi and am therefore basically retarded).

This implements the Provider refactor #69 — I have no idea if it works, because before the actual new mechanism in `curl_executor` can even be tried it continually fails at the transaction validation step.

See:

```
Sat 23:04 hypergrid:ware.hypr: ERROR provider::util: provider/src/util.rs:258: Failed to fetch transaction receipt: provider=haiku-api-testing-4, tx_hash=0x79bc8579b8a14a60c92162594708fe4b1ca96648bc575e57c4232c43b9fe21cd, source_node=mewhenimthermometertesting.os, error=RpcTimeout
Sat 23:04 hypergrid:ware.hypr: ERROR provider: provider/src/lib.rs:502: Payment validation failed for provider 'haiku-api-testing-4' from node 'mewhenimthermometertesting.os': Error fetching transaction receipt for 0x79bc8579b8a14a60c92162594708fe4b1ca96648bc575e57c4232c43b9fe21cd: RpcTimeout
```

That said, actual provider configuration *seems* to work fine and if my goobercoding has preserved the validation logic (highly suspect it might not have) it at least works on that axis. Screenshot of what the curl-based provider config workflow looks like:

<img width="952" height="887" alt="Screenshot 2025-08-16 at 11 11 38 PM" src="https://github.com/user-attachments/assets/dc0a29dd-abaa-4d5e-af61-d68b22592a21" />

It's not quite as stylish as I'd like it to be but I think it's workable. Obviously needs to be tested e2e.